### PR TITLE
changed regex to get filename

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -23,7 +23,7 @@ function activate(context) {
         // The code you place here will be executed every time your command is executed
         let editor = vscode.window.activeTextEditor,
             doc = editor.document,
-            regex = /\/(?:.(?!\/))+$/g,
+            regex = /(.+)[\\\\\/]/g,
             baseFile = doc.fileName,
             swaggerStatic = doc.fileName.replace(doc.fileName.match(regex)[0], '');
 


### PR DESCRIPTION
this is so it works on windows, mac and linux.

The existing regex expression only worked on filenames on mac/linux - eg /home/anthony/git/Source/Repos/comms-api/apiproxy/resources/node/api/swagger/swagger.yaml
This should allow it work on windows as well - eg c:\git\Source\Repos\comms-api\apiproxy\resources\node\api\swagger\swagger.yaml

I have tested this on windows and it works, but dont have a mac or linux machine to test it on so cant confirm it works on there. I have however tested the regex expression and it works with both types of filenames
