### PR TITLE
FIX relative $ref in second level references, to keep relative to roo…

### DIFF
--- a/swagger-editor/config/defaults.json
+++ b/swagger-editor/config/defaults.json
@@ -39,5 +39,5 @@
   "enableTryIt": true,
   "brandingCssClass": "",
   "importProxyUrl": "https://cors-it.herokuapp.com/?url=",
-  "pointerResolutionBasePath": null
+  "pointerResolutionBasePath": "http://localhost:9000/"
 }


### PR DESCRIPTION
FIX relative $ref in second level references, to keep relative to root level as default behaviour in swagger tools.

When adding a $ref on a second level reference, the base bath took, was relative to second level .yaml file, instead of being relatie to origin root .taml file, as default behaviour on swagger tools.

In order to fix base path,  "pointerResolutionBasePath" has been assigned to "http://localhost:9000/" on defaults.json file.

At the moment, the extension does not support a different port, so this should be ok, but this settings should be dinamically modified in case it is required.

